### PR TITLE
[ui_organizer] force to use ANSI version of functions.

### DIFF
--- a/ui_organizer.h
+++ b/ui_organizer.h
@@ -1462,7 +1462,7 @@ void __fastcall UIOLoad(InterfaceManager *interfaceMgr)
 	s_cachedParsedData.Emplace(kTempXMLFile, false, false);
 
 	bufferPtr = s_inclTempBuffer.cache;
-	if (GetPrivateProfileString("General", "sDoNotCache", nullptr, bufferPtr, 0x4000, "Data\\uio\\settings.ini"))
+	if (GetPrivateProfileStringA("General", "sDoNotCache", nullptr, bufferPtr, 0x4000, "Data\\uio\\settings.ini"))
 	{
 		for (; *bufferPtr; bufferPtr = delim)
 		{
@@ -1517,6 +1517,9 @@ void __fastcall UIOLoad(InterfaceManager *interfaceMgr)
 			continue;
 		}
 
+		menuFile = nullptr;
+		tileName = nullptr;
+		pathStr = nullptr;
 		condLine = false;
 		do
 		{
@@ -2426,13 +2429,13 @@ bool NVSEPlugin_Load(const NVSEInterface *nvse)
 	s_baseFilesCache.Init(0x80000);
 	s_inclTempBuffer.Init(0x100000);
 
-	if (GetPrivateProfileInt("General", "bDebugMode", 0, "Data\\uio\\settings.ini"))
+	if (GetPrivateProfileIntA("General", "bDebugMode", 0, "Data\\uio\\settings.ini"))
 	{
 		s_debugMode = true;
 		s_logPath = "uio_debug\\uio_debug.log";
 		PrintLog("Debug mode enabled > Log moved to %s", s_logPath);
 		s_log.Close();
-		CreateDirectory(s_debugPath, NULL);
+		CreateDirectoryA(s_debugPath, NULL);
 		s_log.OpenWrite(s_logPath);
 	}
 	PrintLog("UI Organizer v2.30\nRuntime version = %08X\nNVSE version = %08X\n\n", nvse->runtimeVersion, nvse->nvseVersion);

--- a/utility.cpp
+++ b/utility.cpp
@@ -476,7 +476,7 @@ __declspec(naked) char* __fastcall CopyString(const char *key)
 
 bool __fastcall FileExists(const char *path)
 {
-	UInt32 attr = GetFileAttributes(path);
+	UInt32 attr = GetFileAttributesA(path);
 	return (attr != INVALID_FILE_ATTRIBUTES) && !(attr & FILE_ATTRIBUTE_DIRECTORY);
 }
 

--- a/utility.h
+++ b/utility.h
@@ -126,10 +126,10 @@ bool __fastcall FileExists(const char *path);
 class DirectoryIterator
 {
 	HANDLE				handle;
-	WIN32_FIND_DATA		fndData;
+	WIN32_FIND_DATAA		fndData;
 
 public:
-	DirectoryIterator(const char *path) : handle(FindFirstFile(path, &fndData)) {}
+	DirectoryIterator(const char *path) : handle(FindFirstFileA(path, &fndData)) {}
 	~DirectoryIterator() {Close();}
 
 	bool IsFile() const {return !(fndData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY);}
@@ -151,7 +151,7 @@ public:
 
 	explicit operator bool() const {return handle != INVALID_HANDLE_VALUE;}
 	const char* operator*() const {return fndData.cFileName;}
-	void operator++() {if (!FindNextFile(handle, &fndData)) Close();}
+	void operator++() {if (!FindNextFileA(handle, &fndData)) Close();}
 };
 
 class FileStream


### PR DESCRIPTION
Hello.

In project [set to use Unicode](https://github.com/jazzisparis/UIO-User-Interface-Organizer/blob/main/ui_organizer.vcxproj#L24) version functions, however in macroses used char data that prevent automatic use correct version. Proposed to set directly ANSI version of functions.

Also proposed to set default values for the variables _menuFile_, _tileName_ and _pathStr_.

Thank you.

P.S.
If it do not principal actually use of Unicode versions (UTF-16LE in this case - wchar_t*) is more flexible around the world, but at current propose - no global change to the sources was not apply.